### PR TITLE
restrict isRequestComplete to only the related oracle response

### DIFF
--- a/src/RngWitnet.sol
+++ b/src/RngWitnet.sol
@@ -106,7 +106,8 @@ contract RngWitnet is IRng {
     /// @param _requestId The ID of the request used to get the results of the RNG service
     /// @return isCompleted True if the request has completed and a random number is available, false otherwise
     function isRequestComplete(uint32 _requestId) onlyValidRequest(_requestId) external view returns (bool) {
-        return witnetRandomness.isRandomized(requests[_requestId]);
+        (uint256 witnetQueryId,,) = witnetRandomness.getRandomizeData(requests[_requestId]);
+        return witnetRandomness.witnet().getQueryResponseStatus(witnetQueryId) == WitnetV2.ResponseStatus.Ready;
     }
 
     /// @notice Checks if a given request has failed. If it has, `requestRandomNumber` can be triggered again.


### PR DESCRIPTION
Changed `isRequestComplete` to be consistent with `isRequestFailed` such that it only considers the oracle response that resulted from the request. This provides consistency across the implementation while sacrificing the Witnet order backfill behaviour for requests; meaning that a request will only be considered complete if it's oracle response returned successfully.

The original issue points out a problem that arises from the inconsistent interface where an RNG request can be considered both failed and completed at the same time. This change enforces a consistent interface between the two so bots can make decisions in a more predictable environment.