### PR TITLE
Use call instead of transfer for ETH withdrawal

### DIFF
--- a/src/Requestor.sol
+++ b/src/Requestor.sol
@@ -35,7 +35,7 @@ contract Requestor {
     /// @return The balance of the contract that was transferred
     function withdraw(address payable _to) external onlyCreator returns (uint256) {
         uint balance = address(this).balance;
-        _to.transfer(balance);
+        _to.call{value: balance}("");
         return balance;
     }
 


### PR DESCRIPTION
See [original issue](https://github.com/sherlock-audit/2024-05-pooltogether-judging/issues/80) for details.